### PR TITLE
chore: renaming claim status field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@pankod/refine-react-router-v6": "^3.18.0",
         "@pankod/refine-react-table": "^4.7.2",
         "@pankod/refine-simple-rest": "^3.18.0",
-        "@pankod/refine-strapi-graphql": "^4.9.0",
         "@tabler/icons": "^1.39.1",
         "@testing-library/jest-dom": "^5.12.0",
         "@testing-library/react": "^11.2.6",
@@ -3690,27 +3689,6 @@
       },
       "peerDependencies": {
         "@pankod/refine-core": "^3.23.2"
-      }
-    },
-    "node_modules/@pankod/refine-strapi-graphql": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@pankod/refine-strapi-graphql/-/refine-strapi-graphql-4.9.0.tgz",
-      "integrity": "sha512-qO/ych2VBiNM0qTQygi1zME8U1LStOh/jnfHha4r1cofbVmB63hvZeMnDCGPk9MWZaJwD4ICPCv/GXbKkQVDWA==",
-      "dependencies": {
-        "camelcase": "^6.2.0",
-        "gql-query-builder": "^3.5.5",
-        "graphql": "^15.6.1",
-        "graphql-request": "^4.3.0",
-        "pluralize": "^8.0.0",
-        "query-string": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@pankod/refine-core": "^3.23.2",
-        "gql-query-builder": "^3.5.5",
-        "graphql-request": "^4.3.0"
       }
     },
     "node_modules/@pankod/refine-ui-types": {

--- a/src/interfaces/index.d.ts
+++ b/src/interfaces/index.d.ts
@@ -17,5 +17,5 @@ export interface IClaims {
   date_of_loss: string;
   created_at: string;
   updated_at: string;
-  claim_status: IStatus;
+  status: IStatus;
 }

--- a/src/pages/claims/list.tsx
+++ b/src/pages/claims/list.tsx
@@ -111,13 +111,13 @@ export const ClaimsList: React.FC = () => {
           "date_of_loss",
           "updated_at",
           {
-            claim_status: ["group_name"],
+            status: ["group_name"],
           },
         ],
       },
       permanentFilter: [
         {
-          field: "claim_status.group_name",
+          field: "status.group_name",
           value: selectedStatusGroup,
           operator: "in",
         },


### PR DESCRIPTION
Changes:
claim_status renamed to status in order to match the Hasura fields on dev